### PR TITLE
Use ros1 as devel branch for melodic and noetic.

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -14,7 +14,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
-    devel_branch: master
+    devel_branch: ros1
     last_version: 0.6.0
     name: gazebo_video_monitors
     patches: null
@@ -40,7 +40,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
-    devel_branch: master
+    devel_branch: ros1
     last_version: 0.7.1
     name: gazebo_video_monitors
     patches: null


### PR DESCRIPTION
Reviewing the comment here: https://github.com/ros/rosdistro/pull/38814#issuecomment-1779922802 there was some question as to how bloom picks up the release branch which was answered on thread. This PR is an example of the change implemented by the advice there.